### PR TITLE
Add NPM Supply-Chain Attack link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Grants y entrenamiento: [B4OS](B4os.dev)
 
 
 #### Security
+- [NPM Supply-Chain Attack](https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised)
 - [Not in The Prophecies: Practical Attacks on Nostr](https://eprint.iacr.org/2025/1459)
 - [Qubic reorgs Monero Blockchain](https://qubic.org/pr/qubic-overtakes-monero-s-hash-rate-in-live-51-takeover-demo)
 


### PR DESCRIPTION
This pull request adds a new resource to the Security section in the `README.md` file, expanding the list of supply-chain attack references.

Security resources update:

* Added a link to a blog post about an NPM supply-chain attack involving the `debug` and `chalk` packages.